### PR TITLE
Switch to Amazon Linux 2,  drop --skip-broken

### DIFF
--- a/aws-annex-setup/install_condor
+++ b/aws-annex-setup/install_condor
@@ -1,24 +1,11 @@
 #! /bin/bash
 
-USER=centos
-
-function cont () {
-   return
-   while true; do
-       read -p "Continue (y/n)? " yn
-       case $yn in
-           [Yy]* ) break;;
-           [Nn]* ) exit;;
-           * ) echo "Please answer yes or no.";;
-       esac
-   done
-}
+USER=ec2-user
 
 # ..................................................................................
 echo "============================================================"
 echo "This script installs HTCondor and condor_annex on a yum-based EC2 instance."
 echo "============================================================"
-cont
 
 # ..................................................................................
 # From https://research.cs.wisc.edu/htcondor/instructions/el/7/development/
@@ -28,13 +15,12 @@ wget https://research.cs.wisc.edu/htcondor/yum/RPM-GPG-KEY-HTCondor
 sudo rpm --import RPM-GPG-KEY-HTCondor
 (cd /etc/yum.repos.d; sudo wget https://research.cs.wisc.edu/htcondor/yum/repo.d/htcondor-development-rhel7.repo)
 
-sudo yum install -y condor-all i --skip-broken
+sudo yum install -y condor-all
 
 sudo systemctl enable condor
 sudo systemctl start condor
 
 ps ax | grep condor
-cont
 
 # ..................................................................................
 # From https://htcondor-wiki.cs.wisc.edu/index.cgi/wiki?p=CondorInTheCloudSeedConstruction
@@ -47,7 +33,6 @@ sudo pip install awscli
 
 # ..................................................................................
 echo "Add an AWS role which can run condor_annex and assign it to this EC2."
-cont
 
 echo "Installing local as /etc/condor/config.d/local"
 sudo cp  -v supporting_files/local   /etc/condor/config.d/local

--- a/aws-annex-setup/start_annex
+++ b/aws-annex-setup/start_annex
@@ -7,6 +7,6 @@ IDLE=${4:-$DURATION}
 
 WORKER_AMI="ami-076c79d19eb4a7d37"
 
-condor_annex -annex-name MyFirstAnnex -duration $DURATION  -idle $IDLE  -count $COUNT -owner centos  -aws-on-demand-instance-type $INSTANCE  -aws-on-demand-ami-id $WORKER_AMI
+condor_annex -annex-name MyFirstAnnex -duration $DURATION  -idle $IDLE  -count $COUNT -owner ec2-user  -aws-on-demand-instance-type $INSTANCE  -aws-on-demand-ami-id $WORKER_AMI
 
 

--- a/aws-annex-setup/supporting_files/dot_condor/user_config
+++ b/aws-annex-setup/supporting_files/dot_condor/user_config
@@ -1,2 +1,2 @@
-SEC_PASSWORD_FILE = /home/centos/.condor/condor_pool_password
+SEC_PASSWORD_FILE = /home/ec2-user/.condor/condor_pool_password
 


### PR DESCRIPTION
Switched to Amazon Linux 2.

Corrected typo (extra package "i") in rpm install command and removed--skip-broken which just seemed to exacerbate failed dependency reporting from 2 condor packages to >100 failed dependencies.